### PR TITLE
Handle empty deck in blackjack game

### DIFF
--- a/blackjack_game/blackjack.py
+++ b/blackjack_game/blackjack.py
@@ -33,10 +33,15 @@ class Deck:
     def deal(self):
         """
         Deals one card from the top of the deck.
+
+        Raises
+        ------
+        IndexError
+            If the deck is empty.
         """
-        if len(self.cards) > 0:
-            return self.cards.pop()
-        return None
+        if not self.cards:
+            raise IndexError("All cards have been dealt")
+        return self.cards.pop()
 
 class Hand:
     """

--- a/blackjack_game/test_blackjack.py
+++ b/blackjack_game/test_blackjack.py
@@ -36,6 +36,16 @@ class TestDeck(unittest.TestCase):
         self.assertEqual(card, top_card)
         self.assertNotIn(card, deck.cards)
 
+    def test_deck_deal_empty(self):
+        """
+        Tests that dealing from an empty deck raises an error.
+        """
+        deck = Deck()
+        for _ in range(52):
+            deck.deal()
+        with self.assertRaises(IndexError):
+            deck.deal()
+
 class TestHand(unittest.TestCase):
     """
     Test suite for the Hand class.


### PR DESCRIPTION
## Summary
- raise IndexError when dealing from an empty deck to prevent undefined card values
- add regression test ensuring empty deck deals raise an error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689583ee2a608330b8a53e957b979c39